### PR TITLE
Allow for manual deployment ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Marks a deployment status for GitHub actions.
 - `state`: Deployment state. (default: pending)
 - `description`: Descriptive message about the deployment state.
 - `log-url`: Log url location.
+- `deployment-id`: Optional deployment ID to provide, if this action was triggered outside of a `deployment` event.
 - `token`: Github repository token.
 - `environment`: Name for the target deployment environment, which can be changed when setting a deploy status.
 - `environment-url`: URL for accessing your environment.

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,8 @@ inputs:
     description: 'Github repository token'
   log-url:
     description: 'Log url location'
+  deployment-id:
+    description: 'Optional deployment ID to provide, if this action was triggered outside of a `deployment` event.'
   description:
     description: 'Descriptive message about the deployment state'
   environment:

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ async function run() {
     const token = core.getInput("token", {required: true});
     const state = core.getInput("state", {required: true});
     const url = core.getInput("log-url", {required: false}) || defaultUrl;
+    const deployment_id = core.getInput("deployment-id", {required: false}) || context.payload.deployment.id;
     const description = core.getInput("description", {required: false});
     const env = core.getInput("environment", {required: false});
     const envUrl = core.getInput("environment-url", {required: false});
@@ -16,7 +17,7 @@ async function run() {
     const client = new github.GitHub(token);
     const params = {
       ...context.repo,
-      deployment_id: context.payload.deployment.id,
+      deployment_id: deployment_id,
       state,
       log_url: url,
       target_url: url,


### PR DESCRIPTION
It can be useful to allow for the deployment ID to be provide as `input`, in case a deployment was not triggered by a `deployment` event. For example, if I wanted to autodeploy on every `push` to `production`, I could create a Deployment via the API like this:

```yaml
name: Deploy to Heroku

on:
  push:
    branches:
      - production

jobs:
  deploy:
    name: Heroku Deploy
    runs-on: ubuntu-latest
    steps:
      - name: Check out this repo
        uses: actions/checkout@v2

      - uses: altinukshini/deployment-action@releases/v1
        name: Create GitHub deployment
        if: github.event_name == 'push'
        id: deployment
        with:
          token: "${{ github.token }}"
          environment: production

      - name: "deployment pending"
        uses: "deliverybot/deployment-status@v1"
        with:
          state: "pending"
          token: "${{ github.token }}"
          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
```